### PR TITLE
Unchecked return in Objects/typeobject.c and possible uninitialized variables in cls and new_mro

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -823,15 +823,14 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
         PyTypeObject *cls;
         PyObject *new_mro, *old_mro = NULL;
 
-        if(!PyArg_UnpackTuple(PyList_GET_ITEM(temp, i),
+        if(PyArg_UnpackTuple(PyList_GET_ITEM(temp, i),
                           "", 2, 3, &cls, &new_mro, &old_mro)) {
-            return NULL;
-        }
-        /* Do not rollback if cls has a newer version of MRO.  */
-        if (cls->tp_mro == new_mro) {
-            Py_XINCREF(old_mro);
-            cls->tp_mro = old_mro;
-            Py_DECREF(new_mro);
+           /* Do not rollback if cls has a newer version of MRO.  */
+           if (cls->tp_mro == new_mro) {
+               Py_XINCREF(old_mro);
+               cls->tp_mro = old_mro;
+               Py_DECREF(new_mro);
+           }
         }
     }
     Py_DECREF(temp);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -823,8 +823,10 @@ type_set_bases(PyTypeObject *type, PyObject *new_bases, void *context)
         PyTypeObject *cls;
         PyObject *new_mro, *old_mro = NULL;
 
-        PyArg_UnpackTuple(PyList_GET_ITEM(temp, i),
-                          "", 2, 3, &cls, &new_mro, &old_mro);
+        if(!PyArg_UnpackTuple(PyList_GET_ITEM(temp, i),
+                          "", 2, 3, &cls, &new_mro, &old_mro)) {
+            return NULL;
+        }
         /* Do not rollback if cls has a newer version of MRO.  */
         if (cls->tp_mro == new_mro) {
             Py_XINCREF(old_mro);


### PR DESCRIPTION
The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.

Our AI analyzer found that this function is called for a total of 43 times. Out of these 43 times, the return value from the function call is checked at 42 instances. This is the only instance where the code misses to check the return value for success or failure. 

Once such correct reference usage found in Python/hamt.c at line 2805 .

**Code Extract:**

    PyObject *key;
    PyObject *def = NULL;

    if (!PyArg_UnpackTuple(args, "get", 1, 2, &key, &def)) {
        return NULL;
    }

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
